### PR TITLE
Some category names changed  to display them on topNav

### DIFF
--- a/frontend/src/Components/TopNav/index.js
+++ b/frontend/src/Components/TopNav/index.js
@@ -53,8 +53,7 @@ class TopNav extends Component {
   renderUserDropDown = () =>
     this.state.userDropDown ? <UserDropDown handleLogOut={this.handleLogOut} /> : null;
 
-  render() {
-    const { classes, addLink, titleLink, title, addOrg, user, homePage } = this.props;
+  renderCategories = () => {
     const categoriesData = this.props.categories.categories ? this.props.categories.categories : [];
     const index1 = categoriesData.indexOf("Destitution/NRPF");
     const index2 = categoriesData.indexOf("Employment/Training/Volunteering");
@@ -64,7 +63,12 @@ class TopNav extends Component {
       categoriesData[index2] = "Employment";
       categoriesData[index3] = "Young People and Children";
     }
-    const category = helpers.addSpace(categoriesData, title)
+    return categoriesData
+  }
+
+  render() {
+    const { classes, addLink, titleLink, title, addOrg, user, homePage } = this.props;
+    const category = helpers.addSpace(this.renderCategories(), title)
     return (
       <AppBar className={classes.appBar}>
         <Toolbar>

--- a/frontend/src/Components/TopNav/index.js
+++ b/frontend/src/Components/TopNav/index.js
@@ -56,6 +56,15 @@ class TopNav extends Component {
   render() {
     const { classes, addLink, titleLink, title, addOrg, user, homePage } = this.props;
     const categoriesData = this.props.categories.categories ? this.props.categories.categories : [];
+    const index1 = categoriesData.indexOf("Destitution/NRPF");
+    const index2 = categoriesData.indexOf("Employment/Training/Volunteering");
+    const index3 = categoriesData.indexOf("Young People/Children");
+    if ((index1 !== -1 ) || (index2 !== -1) || (index3 !== -1)){
+      categoriesData[index1] = "Destitution";
+      categoriesData[index2] = "Employment";
+      categoriesData[index3] = "Young People and Children";
+    }
+    const category = helpers.addSpace(categoriesData, title)
     return (
       <AppBar className={classes.appBar}>
         <Toolbar>
@@ -69,7 +78,7 @@ class TopNav extends Component {
               >
                 {addOrg}
                 <Link to={`/${titleLink}`}>
-                  {helpers.addSpace(categoriesData, title)}
+                  {category}
                 </Link>
                 {addOrg || homePage ? null :
                   (


### PR DESCRIPTION
Category names like `Destitution/NRPF` changed  to `Destitution`, `Employment/Training/Volunteering` changed  to `Employment` and `Young People/Children`changed  to `Young People and Children`.
The reason to change the names is because we couldn't display category names which have a forward slash(/) in thier text on topNav.