### PR TITLE
Fix edit orgs hiding card issue

### DIFF
--- a/backend/src/routes/api.js
+++ b/backend/src/routes/api.js
@@ -87,7 +87,7 @@ router.patch('/organisation/edit', async (req, res) => {
         borough: data.borough,
         project: data.project,
         tag: data.tag,
-        Clients: data.clients,
+        clients: data.clients,
         address: [
           {
             id: data.addressId,

--- a/frontend/src/Components/Organisation/EditOrganisation.js
+++ b/frontend/src/Components/Organisation/EditOrganisation.js
@@ -12,31 +12,31 @@ import Spinner from '../Spinner';
 import './edit-org.css';
 
 class EditOrganisation extends React.Component {
-  state = {
-    notificationSystem: null,
-    open: this.props.show,
-    Organisation: "",
-    Area: "",
-    Borough: "",
-    Services: [],
-    Process: "",
-    Day: [],
-    Tel: "",
-    Email: "",
-    Website: "",
-    Categories: [],
-    project: '',
-    tag: '',
-    postcode: '',
-    clients: '',
-    orgId: null,
-    branchId: null,
-    serviceId: null,
-    addressId: null,
-    isChecked: true,
-    isLoading: false
-  };
-
+    state = {
+      notificationSystem: null,
+      open: false,
+      Organisation: "",
+      Area: "",
+      Borough: "",
+      Services: [],
+      Process: "",
+      Day: [],
+      Tel: "",
+      Email: "",
+      Website: "",
+      Categories: [],
+      project: '',
+      tag: '',
+      postcode: '',
+      clients: '',
+      orgId: null,
+      branchId: null,
+      serviceId: null,
+      addressId: null,
+      isChecked: true,
+      isLoading: false
+    }
+  
   componentWillMount() {
     const data = this.props.editOrgData;
     if (data) {
@@ -168,9 +168,12 @@ class EditOrganisation extends React.Component {
   };
 
   handleClose = () => {
-    this.props.stopEditing()
     this.setState({ open: false });
   };
+
+  handleOpenComponent = () => {
+    this.setState({ open : true })
+  }
 
   render() {
     const checkedCategory = helpers.categoryNameMaker(this.props.location.pathname);
@@ -180,7 +183,7 @@ class EditOrganisation extends React.Component {
     return (
       <Fragment>
         <div className="org-edit-btn">
-          <Button className="btn edit-button" onClick={this.props.getData}>
+          <Button className="btn edit-button" onClick={this.handleOpenComponent}>
             <i className="material-icons" size="small" variant="raised" >edit</i>EDIT
           </Button>
         </div>

--- a/frontend/src/Components/Organisation/OrganisationCard.js
+++ b/frontend/src/Components/Organisation/OrganisationCard.js
@@ -23,12 +23,11 @@ const styles = theme => ({
   },
 });
 
-const OrganisationCard = ({
-  org,
-  getData,
-}) => (
+const OrganisationCard = ({ org }) => (
   <Paper label='org-card-info'>
-    <EditOrganisation getData={getData} />
+    <EditOrganisation 
+      editOrgData={org}
+    />
     <SingleOrganisation org={org} />
     
     { /*  Conditionally display services and process, if no info provided display  'not provided' in FE */ }

--- a/frontend/src/Components/Organisation/SingleOrganisation.js
+++ b/frontend/src/Components/Organisation/SingleOrganisation.js
@@ -8,21 +8,7 @@ import './single-org.css';
 
 class SingleOrganisation extends Component {
   state = {
-    open: false,
-    editIdx: -1,
-  };
-
-  editSelectedOrganisation = index =>
-    this.setState({
-      editIdx: index,
-      open: true,
-    });
-
-  stopEditing = () => {
-    this.setState({
-      editIdx: -1,
-      open: false,
-    });
+    open: false
   };
 
   handleOpen = () => {
@@ -34,21 +20,12 @@ class SingleOrganisation extends Component {
   };
   render() {
     const { org } = this.props;
-    const index = 1;
-    const { editIdx } = this.state;
-    const currentlyEditing = editIdx === index;
     const uiMessage = 'Add';
-    return currentlyEditing ? (
-      <EditOrganisation
-        editOrgData={org}
-        stopEditing={this.stopEditing}
-        show
-      />
-    ) : (
+    return (
       <Fragment>
         <div className="org-detail-btn">
           <Button
-            onClick={this.editSelectedOrganisation}
+            onClick={this.handleOpen}
             variant="raised"
             size="small"
             className="btn detail-button"
@@ -72,7 +49,7 @@ class SingleOrganisation extends Component {
           </div> 
 
           <EditOrganisation
-            getData={() => this.editSelectedOrganisation(index)}
+            editOrgData={org}
           />
           {org.org_name.length > 0 ? <h1> {org.org_name} </h1>: <h1 className="not-available"> Add organisation name ... </h1>}
           <h6 className="details-area">

--- a/frontend/src/Components/Organisation/index.js
+++ b/frontend/src/Components/Organisation/index.js
@@ -1,8 +1,6 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import Grid from 'material-ui/Grid';
-import EditOrganisation from './EditOrganisation';
-import SingleOrganisation from './SingleOrganisation';
 import { getBranchsByCategory } from '../../actions/getApiData';
 import { getBranchesFilteredByPostCode } from '../../actions/postData';
 import Search from './Search';
@@ -26,7 +24,6 @@ class Organisations extends Component {
   state = {
     orgsBeforeFilteredByPostcode: [],
     organisations: [],
-    editIdx: -1,
     category: getSelectedCategory(this.props.match),
     day: '',
     borough: '',
@@ -122,15 +119,6 @@ class Organisations extends Component {
       }
     }
   }
-  editSelectedOrganisation = idex =>
-    this.setState({
-      editIdx: idex,
-    });
-  stopEditing = () => {
-    this.setState({
-      editIdx: -1,
-    });
-  };
 
   filterData = (data) => {
     const { day, borough } = this.state;
@@ -200,7 +188,7 @@ class Organisations extends Component {
   }
 
   render() {
-    const { editIdx, category, postCode, borough, day, organisations } = this.state;
+    const { category, postCode, borough, day, organisations } = this.state;
     if (this.state.isLoading || this.filterData.length === 0) {
       return <Spinner />
     }
@@ -225,31 +213,12 @@ class Organisations extends Component {
           isPostcode={this.state.isPostcode}
         />
         <Grid container className="organisation-page" spacing={24} wrap="wrap">
-          {this.filterData(organisations.sort(this.dataOrder())).map((org, index) => {
-            const currentlyEditing = editIdx === index;
-            return currentlyEditing ? (
-              <Fragment>
-                <EditOrganisation
-                  stopEditing={this.stopEditing}
-                  editOrgData={org}
-                  show
-                />
-                <SingleOrganisation
-                  stopEditing={this.stopEditing}
-                  handleShawDetails
-                  org={org}
-                />
-              </Fragment>
-            ) : (
-              <Grid item xs={12} sm={6} key={org.id} className='card'> 
-                <OrganisationCard
-                  getData={() => this.editSelectedOrganisation(index)}
-                  org={org}
-                  index={index}
-                />
-              </Grid>
-              );
-          })}
+          {this.filterData(organisations.sort(this.dataOrder())).map(org => (
+            <Grid item xs={12} sm={6} key={org.id} className='card'> 
+              <OrganisationCard org={org} />
+            </Grid>
+          ))
+          }
         </Grid>
       </div>
     );


### PR DESCRIPTION
Fixed hiding organisation card when press edit an organisation button issue, also fixed editing an organisation issue so it was when try to edit an organisation crash the client side because of we used Clients as a column at edit an organisation API endpoint instead of clients.