### PR TITLE
Fix user DropMenu styling

### DIFF
--- a/frontend/src/Components/Users/user-drop-down.css
+++ b/frontend/src/Components/Users/user-drop-down.css
@@ -4,8 +4,15 @@
   right: 80px;
 }
 .user-drop-down .container{
-  border-radius: 0;
-  margin-right: -4.8rem;
+  font-family: inherit;
+  position: absolute;
+  width: 12em;
+  z-index: 100000;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  height: auto;
+  top: -1px;
+  right: -80px;
 }
 .user-drop-down a:nth-child(1){
   padding: 1em;


### PR DESCRIPTION
Bwfore: 

<img width="474" alt="screen shot 2018-08-14 at 12 11 15" src="https://user-images.githubusercontent.com/26422326/44088507-38293da8-9fbb-11e8-95e6-297459f15f5d.png">

After: 

<img width="442" alt="screen shot 2018-08-14 at 12 10 48" src="https://user-images.githubusercontent.com/26422326/44088514-4117a846-9fbb-11e8-8da4-c81ce5e2a625.png">
