### PR TITLE
Modify fetchNestedObj function to query all branches

### DIFF
--- a/backend/library/helpers.js
+++ b/backend/library/helpers.js
@@ -1,19 +1,86 @@
-function fetchNestedObj(object) {
-  if (object) {
-    return Object.keys(object)
-      .reduce((accumulator, key) => {
-        if (typeof object[key] !== 'object') {
-          accumulator[key] = object[key];
-          return accumulator;
+function fetchNestedObj(obj) {
+  return obj.branch.map(itemObj => {
+    let branches;
+    const { 
+      org_name,
+      website
+    } = obj;
+    const {
+      org_id,
+      borough,
+      project,
+      clients,
+      tag,
+      address,
+      service
+    } = itemObj;
+
+    branches = ({
+      org_name,
+      website,
+      org_id,
+      borough,
+      project,
+      clients,
+      tag
+    });
+
+    address.map(org => {
+      const { branch_id, area, postcode, telephone, email_address, location } = org
+      branches = {
+        ...branches,
+        branch_id,
+        area,
+        postcode,
+        telephone,
+        email_address
+      }
+
+      // Get location key value
+      location.map(locaitem => {
+        const { address_id, lat, long } = locaitem;
+        branches = {
+          ...branches,
+          address_id,
+          lat,
+          long
         }
-        return {
-          ...accumulator,
-          ...fetchNestedObj(object[key])
+      })
+    })
+
+    // Get service key value
+    service.map(serviceItem => {
+      const { 
+        service_days,
+        service,
+        process, 
+        categories
+      } = serviceItem;
+
+      branches = { 
+        ...branches,
+        service_days,
+        service,
+        process
+      };
+
+      categories.map(cat => {
+        const { 
+          service_id,
+           cat_name
+        } = cat;
+
+        branches = { 
+          ...branches,
+          service_id,
+          cat_name
         }
-      }, {});
-  }
-  return null;
+    });
+    })
+    return branches;
+  })
 }
+
 
 // Part of calculation distance function
 function deg2rad(deg) {

--- a/backend/library/helpers.js
+++ b/backend/library/helpers.js
@@ -1,86 +1,19 @@
-function fetchNestedObj(obj) {
-  return obj.branch.map(itemObj => {
-    let branches;
-    const { 
-      org_name,
-      website
-    } = obj;
-    const {
-      org_id,
-      borough,
-      project,
-      clients,
-      tag,
-      address,
-      service
-    } = itemObj;
-
-    branches = ({
-      org_name,
-      website,
-      org_id,
-      borough,
-      project,
-      clients,
-      tag
-    });
-
-    address.map(org => {
-      const { branch_id, area, postcode, telephone, email_address, location } = org
-      branches = {
-        ...branches,
-        branch_id,
-        area,
-        postcode,
-        telephone,
-        email_address
-      }
-
-      // Get location key value
-      location.map(locaitem => {
-        const { address_id, lat, long } = locaitem;
-        branches = {
-          ...branches,
-          address_id,
-          lat,
-          long
+function fetchNestedObj(object) {
+  if (object) {
+    return Object.keys(object)
+      .reduce((accumulator, key) => {
+        if (typeof object[key] !== 'object') {
+          accumulator[key] = object[key];
+          return accumulator;
         }
-      })
-    })
-
-    // Get service key value
-    service.map(serviceItem => {
-      const { 
-        service_days,
-        service,
-        process, 
-        categories
-      } = serviceItem;
-
-      branches = { 
-        ...branches,
-        service_days,
-        service,
-        process
-      };
-
-      categories.map(cat => {
-        const { 
-          service_id,
-           cat_name
-        } = cat;
-
-        branches = { 
-          ...branches,
-          service_id,
-          cat_name
+        return {
+          ...accumulator,
+          ...fetchNestedObj(object[key])
         }
-    });
-    })
-    return branches;
-  })
+      }, {});
+  }
+  return null;
 }
-
 
 // Part of calculation distance function
 function deg2rad(deg) {
@@ -127,7 +60,101 @@ function geoNear(lat, long, latLong) {
   return total.sort((a, b) => parseFloat(a.distance) - parseFloat(b.distance));
 }
 
+
+function fetchNested(obj) {
+  return obj.branch.map(itemObj => {
+    let branches;
+    const {
+      org_name,
+      website
+    } = obj;
+    const {
+      org_id,
+      borough,
+      project,
+      clients,
+      tag
+    } = itemObj;
+
+    branches = ({
+      org_name,
+      website,
+      org_id,
+      borough,
+      project,
+      clients,
+      tag
+    });
+
+    itemObj.address.map(org => {
+      const {
+        branch_id,
+        area,
+        postcode,
+        telephone,
+        email_address
+      } = org
+      branches = {
+        ...branches,
+        branch_id,
+        area,
+        postcode,
+        telephone,
+        email_address
+      }
+
+      // Get location key value
+      org.location.map(locaitem => {
+        const {
+          address_id,
+          lat,
+          long
+        } = locaitem;
+        branches = {
+          ...branches,
+          address_id,
+          lat,
+          long
+        }
+      })
+    })
+
+    // Get service key value
+    itemObj.service.map(serviceItem => {
+      const {
+        service_days,
+        service,
+        process,
+        categories
+      } = serviceItem;
+      branches = {
+        ...branches,
+        service_days,
+        service,
+        process
+      };
+
+      categories.map(cat => {
+        const {
+          service_id,
+          cat_name
+        } = cat
+
+        branches = {
+          ...branches,
+          service_id,
+          cat_name
+        }
+      })
+    })
+    return branches;
+  })
+}
+
+
+
 export default {
   fetchNestedObj,
+  fetchNested,
   geoNear
 };

--- a/backend/src/controllers/get_controller.js
+++ b/backend/src/controllers/get_controller.js
@@ -11,6 +11,19 @@ module.exports = {
         .query()
         .eager('[branch, branch.[address, address.[location] service, service.[categories]] ]')
         .map(data => helpers.fetchNestedObj(data));
+      return result;
+    } catch (error) {
+      return error;
+    }
+  },
+
+
+  getAllBranches: async () => {
+    try {
+      const result = await Organisation
+        .query()
+        .eager('[branch, branch.[address, address.[location] service, service.[categories]] ]')
+        .map(data => helpers.fetchNested(data));
       return [].concat(...result);
     } catch (error) {
       return error;

--- a/backend/src/controllers/get_controller.js
+++ b/backend/src/controllers/get_controller.js
@@ -11,7 +11,7 @@ module.exports = {
         .query()
         .eager('[branch, branch.[address, address.[location] service, service.[categories]] ]')
         .map(data => helpers.fetchNestedObj(data));
-      return result;
+      return [].concat(...result);
     } catch (error) {
       return error;
     }

--- a/backend/src/routes/api.js
+++ b/backend/src/routes/api.js
@@ -9,7 +9,8 @@ import {
   getBranchesByCategory,
   getBranchesByDay,
   getBranchesByBorough,
-  getBranchesByPostcode
+  getBranchesByPostcode,
+  getAllBranches
 } from '../controllers/get_controller';
 
 const router = express.Router();
@@ -150,6 +151,15 @@ router.put('/organisation/edit', async (req, res) => {
 router.get('/all', async (req, res) => {
   try {
     await getAllOrgainisation().then(services =>
+      res.status(200).json(services));
+  } catch (err) {
+    res.status(502).json(err)
+  }
+});
+
+router.get('/branches', async (req, res) => {
+  try {
+    await getAllBranches().then(services =>
       res.status(200).json(services));
   } catch (err) {
     res.status(502).json(err)

--- a/frontend/src/actions/getApiData.js
+++ b/frontend/src/actions/getApiData.js
@@ -33,7 +33,7 @@ export function setOrganisationsList(organisations) {
 export function getOrganisationsList(){
   const sendInfo = async (dispatch) => {
     try {
-      const res = await axios.get(`${api}/service/all`)
+      const res = await axios.get(`${api}/service/branches`)
       return dispatch(setOrganisationsList(res.data))
     } catch (error) {
       return helpers.errorParser(error)


### PR DESCRIPTION
# Description
Aim: Make ` getAllOrgainisation` to return all branches of every single organisation and not only one branch as it does currently. Example On home search if you search for `999 Club`` you will get only one branch  as this component consumes `http://localhost:3002/api/service/all`  which returns for every single organisation only one branch which is then display on client