### PR TITLE
Make edit button only available on detail organisation card

### DIFF
--- a/frontend/src/Components/Organisation/OrganisationCard.js
+++ b/frontend/src/Components/Organisation/OrganisationCard.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { withStyles } from 'material-ui/styles';
 import Paper from './PaperOrg';
 import SingleOrganisation from './SingleOrganisation';
-import EditOrganisation from './EditOrganisation';
 import './index.css';
 
 
@@ -27,13 +26,8 @@ const OrganisationCard = ({
   isHomeRoute
 }) => (
   <Paper label='org-card-info'>
-    { role === 'Admin' || role === 'Editor' ?
-      <EditOrganisation org={org} /> : null
-    }
     <SingleOrganisation org={org} role={role} />
-
     { /*  Conditionally display services and process, if no info provided display  'not provided' in FE */ }
-
     { org.org_name ?
       <span className={org.distance || org.distance === null ? 'org-distance': ''}>
         <h1>{org.org_name}</h1>

--- a/frontend/src/Components/Organisation/PaperOrg.css
+++ b/frontend/src/Components/Organisation/PaperOrg.css
@@ -86,12 +86,6 @@ div.org-card-info {
 .org-card-info .org-edit-btn,
 .org-info .org-close-btn{ height: 0;}
 
-.org-card-info .org-detail-btn button {
-  top: 8.2rem;
-  right: 0;
-  left: 43%;
-}
-
 .org-info .org-edit-btn {
   bottom: 6px;
   right: 7px;

--- a/frontend/src/Components/Organisation/SingleOrganisation.js
+++ b/frontend/src/Components/Organisation/SingleOrganisation.js
@@ -33,9 +33,9 @@ class SingleOrganisation extends Component {
             onClick={this.handleOpen}
             variant="raised"
             size="small"
-            className={role !== 'Admin' && role !== 'Editor' ? 'move-right' : 'btn detail-button'}
+            className='move-right'
           >
-            <i className="material-icons">add</i>DETAILS
+          View details <i className="material-icons" > arrow_right_alt </i>
           </Button>
         </div>
         <Dialog

--- a/frontend/src/Components/Organisation/index.css
+++ b/frontend/src/Components/Organisation/index.css
@@ -6,8 +6,12 @@
   color: #ccc;
 }
 
-/* allow to control font-size in org card detail by modify font-sie of  div parent */
-/* .org-info { font-size: 15px; } */
+/* Remove background default color & shadow when button is hover */
+.organisation-page button:hover,
+.organisation-page button:active {
+  background: transparent;
+  box-shadow: none;
+}
 
 /* label title org edit - org detail info  */
 .edit-content .normal-weight,

--- a/frontend/src/Components/Organisation/single-org.css
+++ b/frontend/src/Components/Organisation/single-org.css
@@ -75,11 +75,23 @@
 }
 
 .org-detail-btn .move-right{
-  left: 81% !important;
+  font-size: 15px;
+  color: #1abcd4;
+  left: 73% ;
+  top: 8.1rem;
+  right: 0;
   border-radius: 0;
   background-color: transparent;
   border: 0;
   box-shadow: 0 0;
+  text-transform: inherit;
+}
+
+/* Arrow button  */
+.move-right i{
+  padding-left: .2rem;
+  font-size: 25px;
+  font-weight: bolder;
 }
 
 .org-info .edit-button {
@@ -127,6 +139,6 @@
 
 @media (max-width: 767px){
   .org-detail-btn .move-right{
-    left: 75% !important;
+    left: 65%;
   }
 }


### PR DESCRIPTION
# Description
Make the edit button only available on organisation card detail 
# Picture
<img width="1080" alt="removebtn" src="https://user-images.githubusercontent.com/30389858/46156444-69fbc200-c271-11e8-9741-da9e0811e446.PNG">
