### PR TITLE
fix the search in categories

### DIFF
--- a/frontend/src/Components/Organisation/Search.js
+++ b/frontend/src/Components/Organisation/Search.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { connect } from "react-redux";
 import Button from "material-ui/Button";
 import PropTypes from "prop-types";
 import Grid from "material-ui/Grid";
@@ -12,6 +13,7 @@ import "react-select/dist/react-select.css";
 import helpers from "../../helpers";
 import searchStyle from "./searchStyle";
 import "./search.css";
+import { getOrganisationsList } from '../../actions/getApiData';
 
 const organisations = [
   { postCode: "SE8 4PA" },
@@ -59,12 +61,25 @@ const days = [
 
 class Search extends React.Component {
   state = {
-    suggestions: []
+    suggestions: [],
+    organisations: []
   };
+  componentWillReceiveProps(newProps) {
+    (() => {
+      const org = []
+      newProps.organisations.map(organisation => org.push({postCode: organisation.postcode}))
+      const filterOrg = org.filter((element, index, self) =>
+      index === self.findIndex((current) => (
+        current.postCode === element.postCode
+        ))
+        )
+        this.setState({organisations: filterOrg})
+      })()
+  }
 
   handleSuggestionsFetchRequested = ({ value }) => {
     this.setState({
-      suggestions: helpers.getSuggestions(value, organisations)
+      suggestions: helpers.getSuggestions(value, this.state.organisations)
     });
   };
 
@@ -100,7 +115,8 @@ class Search extends React.Component {
                 placeholder: "Enter postcode or borough...",
                 name: "postCode",
                 value: this.props.searchInput,
-                onChange: this.props.handlePostCodeChange
+                onChange: this.props.handlePostCodeChange,
+                onKeyUp: this.props.handleKeyUp
               }}
             />
             <button
@@ -163,4 +179,9 @@ Search.propTypes = {
   classes: PropTypes.object.isRequired
 };
 
-export default withStyles(searchStyle.styles)(Search);
+function mapStateToProps(state) {
+  return {
+    organisations: state.filteredBranchsByCategory.branchs
+  }
+}
+export default connect(mapStateToProps , { getOrganisationsList })(withStyles(searchStyle.styles)(Search));

--- a/frontend/src/Components/Organisation/Search.js
+++ b/frontend/src/Components/Organisation/Search.js
@@ -15,11 +15,7 @@ import searchStyle from "./searchStyle";
 import "./search.css";
 import { getOrganisationsList } from '../../actions/getApiData';
 
-const organisations = [
-  { postCode: "SE8 4PA" },
-  { postCode: "H2 2TH" },
-  { postCode: "H2 3TH" }
-];
+
 const days = [
   {
     id: 1,

--- a/frontend/src/Components/Organisation/index.js
+++ b/frontend/src/Components/Organisation/index.js
@@ -76,10 +76,16 @@ class Organisations extends Component {
       });
     }
   };
+  handleKeyUp = (e) => {
+    this.handlePostSearch(e)
+ }
 
   handlePostCodeChange = (event, { newValue }) => {
+    this.handlePostSearch(event, newValue)
+    this.clearPostcodeField()
     this.setState(
       {
+        organisations: this.props.organisation,
         searchInput: newValue,
         isPostcode: true
       },
@@ -87,7 +93,8 @@ class Organisations extends Component {
     );
   };
 
-  handlePostSearch = async () => {
+  handlePostSearch = async (event) => {
+    event.preventDefault();
     const { searchInput } = this.state;
     const isAlphaNumeric = helpers.isAlphaNumeric(searchInput);
     if (isAlphaNumeric) {
@@ -196,6 +203,7 @@ class Organisations extends Component {
           postcodeError={this.state.postcodeError}
           clearPostcodeField={this.clearPostcodeField}
           isPostcode={this.state.isPostcode}
+          handleKeyUp={this.handleKeyUp}
         />
         <Grid container className="organisation-page" spacing={24} wrap="wrap">
           {orgHelpers

--- a/frontend/src/Components/Organisation/index.js
+++ b/frontend/src/Components/Organisation/index.js
@@ -77,7 +77,6 @@ class Organisations extends Component {
     }
   };
 
-
   handlePostCodeChange = (event, { newValue }) => {
     this.handlePostSearch(event, newValue)
     this.clearPostcodeField()

--- a/frontend/src/Components/Organisation/index.js
+++ b/frontend/src/Components/Organisation/index.js
@@ -76,9 +76,7 @@ class Organisations extends Component {
       });
     }
   };
-  handleKeyUp = (e) => {
-    this.handlePostSearch(e)
- }
+
 
   handlePostCodeChange = (event, { newValue }) => {
     this.handlePostSearch(event, newValue)
@@ -203,7 +201,7 @@ class Organisations extends Component {
           postcodeError={this.state.postcodeError}
           clearPostcodeField={this.clearPostcodeField}
           isPostcode={this.state.isPostcode}
-          handleKeyUp={this.handleKeyUp}
+          handleKeyUp={this.handlePostSearch}
         />
         <Grid container className="organisation-page" spacing={24} wrap="wrap">
           {orgHelpers

--- a/frontend/src/_test_/Search.test.js
+++ b/frontend/src/_test_/Search.test.js
@@ -1,13 +1,24 @@
 import React from 'react'
+import configureStore from 'redux-mock-store'
+import { Provider } from 'react-redux';
 import { shallow, configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import Search from '../Components/Organisation/Search';
 
+const middlewares = []
+const mockStore = configureStore(middlewares)
 configure({ adapter: new Adapter() });
 
 describe('Search Component', () => {
     it('Should render without crashing', () => {
-        const wrapper = shallow(<Search />).length
-        expect(wrapper).toEqual(1)
+        const initialState = {}
+        const store = mockStore(initialState)
+      //  const wrapper = shallow(<Search />,  { context: { store }}).length
+
+      const wrapper = shallow(
+        <Provider store={store}>
+          <Search />
+        </Provider>).length
+      expect(wrapper).toEqual(1)
     })
 })

--- a/frontend/src/_test_/Search.test.js
+++ b/frontend/src/_test_/Search.test.js
@@ -13,8 +13,6 @@ describe('Search Component', () => {
     it('Should render without crashing', () => {
         const initialState = {}
         const store = mockStore(initialState)
-      //  const wrapper = shallow(<Search />,  { context: { store }}).length
-
       const wrapper = shallow(
         <Provider store={store}>
           <Search />


### PR DESCRIPTION
# Description

1. To search for multiple things without refreshing the page.
2. As soon as you delete the work in the search bar it brings you the entire list. (Hot reloading) No need to refresh or to click anything.
3. Display the list of all the `post codes` available for that specific category.
4. No Duplication on the suggested list.
5. When user clicks `enter` it should search.
6. It hot reloads as soon as you start typing.